### PR TITLE
fix undefined reference error to libudev

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -19,7 +19,7 @@ $(OUT)/%.o: %.c | $(BUILT_HEADERS)
 $(EXE): $(OBJS)
 	@mkdir -p $(dir $@)
 	@echo "  CCLD    $@"
-	@+$(CC) $(LDFLAGS) $^ -o $@
+	@+$(CC) $^ $(LDFLAGS) -o $@
 
 run: all
 	@echo "  $(EXE)"


### PR DESCRIPTION
If i try to compile the current repo I get a bunch of undefined reference errors such as

```
undefined reference to `udev_new'
```

Using the solution to move LDFLAGS to the end of the linking line fixed it for me, same as here:
http://stackoverflow.com/questions/27168739/compilation-error-undefined-reference-to
